### PR TITLE
[Bug] Prevent XSS by using textContent rather than innerHTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ session's `signal` event handler is invoked:
 
     session.on('signal:chat', function(event) {
       var msg = document.createElement('p');
-      msg.innerText = event.data;
+      msg.textContent = event.data;
       msg.className = event.from.connectionId === session.connection.connectionId ? 'mine' : 'theirs';
       msgHistory.appendChild(msg);
       msg.scrollIntoView();

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ session's `signal` event handler is invoked:
 
     session.on('signal:chat', function(event) {
       var msg = document.createElement('p');
-      msg.innerHTML = event.data;
+      msg.innerText = event.data;
       msg.className = event.from.connectionId === session.connection.connectionId ? 'mine' : 'theirs';
       msgHistory.appendChild(msg);
       msg.scrollIntoView();

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -51,7 +51,7 @@ function initializeSession() {
   var msgHistory = document.querySelector('#history');
   session.on('signal:msg', function(event) {
     var msg = document.createElement('p');
-    msg.innerHTML = event.data;
+    msg.innerText = event.data;
     msg.className = event.from.connectionId === session.connection.connectionId ? 'mine' : 'theirs';
     msgHistory.appendChild(msg);
     msg.scrollIntoView();

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -51,7 +51,7 @@ function initializeSession() {
   var msgHistory = document.querySelector('#history');
   session.on('signal:msg', function(event) {
     var msg = document.createElement('p');
-    msg.innerText = event.data;
+    msg.textContent = event.data;
     msg.className = event.from.connectionId === session.connection.connectionId ? 'mine' : 'theirs';
     msgHistory.appendChild(msg);
     msg.scrollIntoView();


### PR DESCRIPTION
Due to the use of innerHTML in the signalling demo there is an [XSS](https://en.wikipedia.org/wiki/Cross-site_scripting) security hole open.

This should be replaced with textContent to prevent execution of arbitrary Javascript on others' browsers.

**Steps to reproduce:**
1. Run app in 2 windows
2. Send the following message: `<img src="https://static.opentok.com/img/homepage/t-b-logo.svg" onload="alert('Evil')"/>`
3. Observe an alert box appearing in both windows

The README in the basics and archiving branches should be updated too.
